### PR TITLE
changed to provision automatically

### DIFF
--- a/install_in_box.sh
+++ b/install_in_box.sh
@@ -3,3 +3,6 @@
 sudo apt-add-repository ppa:ansible/ansible -y
 sudo apt-get update -y
 sudo apt-get install -y software-properties-common ansible git
+git clone https://github.com/fred4jupiter/graylog2-in-a-box.git /home/vagrant/graylog2-in-a-box
+cd /home/vagrant/graylog2-in-a-box/provisioning
+sudo ansible-playbook -i inventory playbook.yml


### PR DESCRIPTION
Readme sagt, welche manuellen Schritte notwendig sind. Warum nicht automatisch?
Vorschlag wäre hier im PR.
